### PR TITLE
Set http.use_ssl with @options[:use_ssl] default false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /test/reports/
 .rakeTasks
 /influxdb-client-*.gem
+/TAGS

--- a/lib/influxdb/client/write_api.rb
+++ b/lib/influxdb/client/write_api.rb
@@ -96,6 +96,7 @@ module InfluxDB
       http.open_timeout = @options[:open_timeout] || DEFAULT_TIMEOUT
       http.write_timeout = @options[:write_timeout] || DEFAULT_TIMEOUT if Net::HTTP.method_defined? :write_timeout
       http.read_timeout = @options[:read_timeout] || DEFAULT_TIMEOUT
+      http.use_ssl = @options[:use_ssl] || false
 
       request = Net::HTTP::Post.new(uri.request_uri)
       request['Authorization'] = "Token #{@options[:token]}"


### PR DESCRIPTION
Copied from fork: https://github.com/bednar/influxdb-client-ruby/pull/1
cc @giovannelli

-------

Hi @bednar,
I'm testing influxdb 2.0 but with my cloud endpoint I got this:

```
JSON::ParserError (767: unexpected token at '<html>
<head><title>400 The plain HTTP request was sent to HTTPS port</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<center>The plain HTTP request was sent to HTTPS port</center>
<hr><center>openresty</center>
</body>
</html>
```
use_ssl option fix the issue, but I'm still not able to write a point! Getting this

```
<Net::HTTPNoContent 204 No Content readbody=true> 
```
Does this ring any bell to you?

Thank you,
Duccio
